### PR TITLE
CMake: revert to 2.8.11.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,11 @@
 #   Francois Gindraud (2017)
 # Created: 17/09/2010
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 2.8.11)
 project (bpp-core CXX)
 
 # Compile options
-set (private-compile-options -std=c++11 -Wall -Weffc++ -Wshadow -Wconversion)
+set (CMAKE_CXX_FLAGS "-std=c++11 -Wall -Weffc++ -Wshadow -Wconversion")
 
 IF(NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,4 +1,4 @@
-This software needs cmake >= 2.8.12 and a C++11 capable compiler to build
+This software needs cmake >= 2.8.11 and a C++11 capable compiler to build
 
 After installing cmake, run it with the following command:
 $ cmake -DCMAKE_INSTALL_PREFIX=[where to install, for instance /usr/local or $HOME/.local] .

--- a/cmake/doc-cmake-for-developpers.cmake
+++ b/cmake/doc-cmake-for-developpers.cmake
@@ -11,9 +11,9 @@
 # Main CMakeLists.txt
 ####################################################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
-# 2.8.12 is required for:
-# - clean target properties (link, include dir, compile options)
+cmake_minimum_required (VERSION 2.8.11)
+# 2.8.11 is required for:
+# - clean target properties (link, include dir)
 
 project (bpp-something CXX)
 # Defines a lot of stuff including PROJECT_NAME which will contain "bpp-something"
@@ -23,14 +23,10 @@ project (bpp-something CXX)
 # - the CMake package
 # Do not change it unless there is a good reason...
 
-set (public-compile-options)
-set (private-compile-options std=c++11 -Wall -Weffc++ -Wshadow -Wconversion)
-# Define compile options to be used with targets (will be used later).
-# Public options will be used to compile the libs and added as a required compile option for
-# dependencies (tests, other bpp components, user programs compiled with cmake).
-# Private options are only used to compute the libraries.
-# NOTES:
-# -> public-compile-options was previously used to propagate -std=c++11, but this forced user to user c++11 (instead of c++14 for example). This also made C/C++ interaction problematic as -std=c++11 was given to gcc for C files too in bpp-raa.
+set (CMAKE_CXX_FLAGS "std=c++11 -Wall -Weffc++ -Wshadow -Wconversion")
+# Define compile options to be used for all C++ targets.
+# NOTES for the future:
+# -> CMake >= 2.8.12 adds per target COMPILE_OPTIONS by using target_compile_options (<target> [PRIVATE|PUBLIC] <opt1> ... <optN>)
 # -> CMake >= 3.1.x provides a CXX_STANDARD variable to set -std=...
 # -> It also provides a "feature" property on targets which annotates, and auto selects the right -std=...
 
@@ -140,14 +136,6 @@ target_link_libraries (${PROJECT_NAME}-static ${BPP_LIBS_STATIC})
 # "Links" to all bpp components included by find_package (adds everything, -I, -L -lbpp-comps...)
 # (a manual list of bpp components targets also works here).
 
-target_compile_options (${PROJECT_NAME}-static
-  PUBLIC ${public-compile-options}
-  PRIVATE ${private-compile-options}
-  )
-# Adds compile options to library.
-# Public options are used to build the library, and propagated to targets that link to this library.
-# Private options are only used to build the library.
-
 add_library (${PROJECT_NAME}-shared SHARED ${CPP_FILES})
 target_include_directories (${PROJECT_NAME}-shared PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -239,9 +227,6 @@ foreach (test_cpp_file ${test_cpp_files})
 
   target_link_libraries (${test_name} ${PROJECT_NAME}-shared)
   # Link to bpp-something shared library (pulls required -I -L -lbpp-*).
-
-  target_compile_options (${test_name} PRIVATE ${private-compile-options})
-  # Compile options (mostly -std=c++11).
 
   add_test (
     NAME ${test_name}

--- a/cmake/project-template-for-users.cmake
+++ b/cmake/project-template-for-users.cmake
@@ -12,7 +12,7 @@
 # This is a basic configuration for users with Bio++ libraries installed in a standard system place (/usr/).
 
 # These two lines are CMake boilerplate
-cmake_minimum_required (VERSION 2.8.12) # Test of version. 2.8.12 is the oldest version supported by Bio++
+cmake_minimum_required (VERSION 2.8.11) # Test of version. 2.8.11 is the oldest version supported by Bio++
 project (myproject CXX) # The name is not critical
 
 # Find Bio++ libraries and import their configurations.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,10 +104,6 @@ target_include_directories (${PROJECT_NAME}-static PUBLIC
   )
 set_target_properties (${PROJECT_NAME}-static PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 target_link_libraries (${PROJECT_NAME}-static ${BPP_LIBS_STATIC})
-target_compile_options (${PROJECT_NAME}-static
-  PUBLIC ${public-compile-options}
-  PRIVATE ${private-compile-options}
-  )
 
 # Build the shared lib
 add_library (${PROJECT_NAME}-shared SHARED ${CPP_FILES})
@@ -122,10 +118,6 @@ set_target_properties (${PROJECT_NAME}-shared
   SOVERSION ${${PROJECT_NAME}_VERSION_MAJOR}
   )
 target_link_libraries (${PROJECT_NAME}-shared ${BPP_LIBS_SHARED})
-target_compile_options (${PROJECT_NAME}-shared
-  PUBLIC ${public-compile-options}
-  PRIVATE ${private-compile-options}
-  )
 
 # Install libs and headers
 install (

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,6 @@ foreach (test_cpp_file ${test_cpp_files})
   get_filename_component (test_name ${test_cpp_file} NAME_WE)
   add_executable (${test_name} ${test_cpp_file})
   target_link_libraries (${test_name} ${PROJECT_NAME}-shared)
-  target_compile_options (${test_name} PRIVATE ${private-compile-options})
   add_test (
     NAME ${test_name}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
Redhat seems stuck with 2.8.11.
-> Removing the 2.8.12 feature of using target_compile_options.
-> Using the old set CMAKE_CXX_FLAGS
-> Updated doc