### PR TITLE
Fix to avoid CMake 2.8.11 spurious error

### DIFF
--- a/cmake/doc-cmake-for-developpers.cmake
+++ b/cmake/doc-cmake-for-developpers.cmake
@@ -121,13 +121,14 @@ add_library (${PROJECT_NAME}-static STATIC ${CPP_FILES})
 
 target_include_directories (${PROJECT_NAME}-static PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:include>
+  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
   )
 # Annotates the static lib target with include paths.
 # These paths will be added as -I options:
 # - during compilation of the target, by looking at CMAKE_CURRENT_SOURCE_DIR
 # - during compilation of anything that links to this target, by looking at <install_dir>/include.
 # This allow the code to reference headers by a path relative to src/ instead of using ../OtherDir/blah.h
+# NOTE the "$<INSTALL_PREFIX>/" part is only needed to support 2.8.11 due to a bugged cmake check.
 
 set_target_properties (${PROJECT_NAME}-static PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 # Set target file name (default is the target name)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,7 +100,7 @@ set (CPP_FILES
 add_library (${PROJECT_NAME}-static STATIC ${CPP_FILES})
 target_include_directories (${PROJECT_NAME}-static PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:include>
+  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
   )
 set_target_properties (${PROJECT_NAME}-static PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 target_link_libraries (${PROJECT_NAME}-static ${BPP_LIBS_STATIC})
@@ -109,7 +109,7 @@ target_link_libraries (${PROJECT_NAME}-static ${BPP_LIBS_STATIC})
 add_library (${PROJECT_NAME}-shared SHARED ${CPP_FILES})
 target_include_directories (${PROJECT_NAME}-shared PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:include>
+  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
   )
 set_target_properties (${PROJECT_NAME}-shared
   PROPERTIES OUTPUT_NAME ${PROJECT_NAME}


### PR DESCRIPTION
CMake 2.8.11 has a check that fails because it sees a relative "include"
dir as target_include_directories.
However it is in a conditional expression (INSTALL_INTERFACE) that is
supposed to prepend the install prefix (thus no relative path in the
end).
The check still fails, probably an internal error in 2.8.11 (no problem
for any version above that).

To fix it, the install prefix is prepended manually.
It is refered to using a generator expression instead of
CMAKE_INSTALL_PREFIX : with the CMAKE_... variable it changes the
output, not with the generator expression.

Updated doc.