### PR TITLE
Fixes #13: Invalid read (valgrind) in GlobalGraph::switchNodes

### DIFF
--- a/src/Bpp/Graph/GlobalGraph.cpp
+++ b/src/Bpp/Graph/GlobalGraph.cpp
@@ -181,7 +181,7 @@ void GlobalGraph::switchNodes(Graph::NodeId nodeA, Graph::NodeId nodeB)
   }
 
   // Edge
-  GlobalGraph::Edge& foundEdge = foundForwardRelation->second;
+  GlobalGraph::Edge foundEdge = foundForwardRelation->second;
 
   // Backwards
   map<GlobalGraph::Node, GlobalGraph::Edge>::iterator foundBackwardsRelation = nodeSonRow->second.second.find(father);


### PR DESCRIPTION
Change GlobalGraph::Edge reference for a value (line 184).
Solved problems after reroots in trees using GlobalGraph.