### PR TITLE
Update Font.h

### DIFF
--- a/src/Bpp/Graphics/Font/Font.h
+++ b/src/Bpp/Graphics/Font/Font.h
@@ -94,24 +94,24 @@ class Font:
     /**
      * @return The style component of this font.
      */
-    const short int getStyle() const { return style_; }
+    short int getStyle() const { return style_; }
 
     /**
      * @brief Alias function for getStyle.
      * @return The shape component of this font.
      */
-    const short int getShape() const { return style_; }
+    short int getShape() const { return style_; }
 
     /**
      * @return The weight component of this font.
      */
-    const short int getWeight() const { return weight_; }
+    short int getWeight() const { return weight_; }
 
     /**
      * @brief Alias function for getWeight
      * @return The series component of this font.
      */
-    const short int getSeries() const { return weight_; }
+    short int getSeries() const { return weight_; }
 
     /**
      * @return The size component of this font.


### PR DESCRIPTION
'const' is ignored on primitive return values. This is caught by `-Wextra` by the way.